### PR TITLE
feat: add org_id parameter support throughout CLI and PGDN library

### DIFF
--- a/pgdn/parallel.py
+++ b/pgdn/parallel.py
@@ -173,7 +173,8 @@ class ParallelOperations:
                                     force_rescore: bool = False,
                                     host: Optional[str] = None,
                                     use_queue: bool = False,
-                                    wait_for_completion: bool = False) -> Dict[str, Any]:
+                                    wait_for_completion: bool = False,
+                                    org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Coordinate a complete parallel operation based on provided parameters.
         
@@ -190,6 +191,7 @@ class ParallelOperations:
             host: Host for discovery stage
             use_queue: Whether to use queue
             wait_for_completion: Whether to wait for completion
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             dict: Coordination results
@@ -206,7 +208,8 @@ class ParallelOperations:
                         'protocol_filter': protocol_filter,
                         'debug': debug,
                         'force_rescore': force_rescore,
-                        'host': host
+                        'host': host,
+                        'org_id': org_id
                     }
                 
                 return self.run_parallel_stages(
@@ -220,7 +223,7 @@ class ParallelOperations:
                     targets = load_targets_from_file(target_file)
                 
                 return self.run_parallel_scans(
-                    targets, max_parallel, protocol_filter, debug, use_queue, wait_for_completion
+                    targets, max_parallel, protocol_filter, debug, use_queue, wait_for_completion, org_id=org_id
                 )
             
             else:

--- a/pgdn/pipeline.py
+++ b/pgdn/pipeline.py
@@ -37,19 +37,20 @@ class PipelineOrchestrator:
             self._orchestrator = create_orchestrator(self.config)
         return self._orchestrator
     
-    def run_full_pipeline(self, recon_agents: Optional[List[str]] = None) -> Dict[str, Any]:
+    def run_full_pipeline(self, recon_agents: Optional[List[str]] = None, org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Run the complete four-stage pipeline.
         
         Args:
             recon_agents: Optional list of specific recon agents to run
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             dict: Pipeline execution results including success status, execution_id,
                   timing, and stage results
         """
         try:
-            results = self.orchestrator.run_full_pipeline(recon_agents=recon_agents)
+            results = self.orchestrator.run_full_pipeline(recon_agents=recon_agents, org_id=org_id)
             
             return {
                 "success": results['success'],
@@ -66,18 +67,19 @@ class PipelineOrchestrator:
                 "timestamp": datetime.now().isoformat()
             }
     
-    def run_recon_stage(self, agent_names: Optional[List[str]] = None) -> Dict[str, Any]:
+    def run_recon_stage(self, agent_names: Optional[List[str]] = None, org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Run only the reconnaissance stage.
         
         Args:
             agent_names: Optional list of specific recon agents to run
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             dict: Reconnaissance results
         """
         try:
-            results = self.orchestrator.run_single_stage('recon', agent_names=agent_names)
+            results = self.orchestrator.run_single_stage('recon', agent_names=agent_names, org_id=org_id)
             
             return {
                 "success": True,
@@ -95,18 +97,19 @@ class PipelineOrchestrator:
                 "timestamp": datetime.now().isoformat()
             }
     
-    def run_process_stage(self, agent_name: Optional[str] = None) -> Dict[str, Any]:
+    def run_process_stage(self, agent_name: Optional[str] = None, org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Run only the processing stage.
         
         Args:
             agent_name: Optional specific agent name to use
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             dict: Processing results
         """
         try:
-            results = self.orchestrator.run_single_stage('process', agent_name)
+            results = self.orchestrator.run_single_stage('process', agent_name, org_id=org_id)
             
             return {
                 "success": True,
@@ -124,19 +127,20 @@ class PipelineOrchestrator:
                 "timestamp": datetime.now().isoformat()
             }
     
-    def run_scoring_stage(self, agent_name: str = 'ScoringAgent', force_rescore: bool = False) -> Dict[str, Any]:
+    def run_scoring_stage(self, agent_name: str = 'ScoringAgent', force_rescore: bool = False, org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Run only the scoring stage.
         
         Args:
             agent_name: Agent name to use for scoring
             force_rescore: Whether to force re-scoring of existing results
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             dict: Scoring results
         """
         try:
-            results = self.orchestrator.run_scoring_stage(agent_name, force_rescore=force_rescore)
+            results = self.orchestrator.run_scoring_stage(agent_name, force_rescore=force_rescore, org_id=org_id)
             
             return {
                 "success": True,
@@ -154,19 +158,20 @@ class PipelineOrchestrator:
                 "timestamp": datetime.now().isoformat()
             }
     
-    def run_publish_stage(self, agent_name: str, scan_id: int) -> Dict[str, Any]:
+    def run_publish_stage(self, agent_name: str, scan_id: int, org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Run only the publishing stage.
         
         Args:
             agent_name: Agent name to use for publishing ('PublishLedgerAgent' or 'PublishReportAgent')
             scan_id: Scan ID to publish results for
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             dict: Publishing results
         """
         try:
-            results = self.orchestrator.run_publish_stage(agent_name, scan_id=scan_id)
+            results = self.orchestrator.run_publish_stage(agent_name, scan_id=scan_id, org_id=org_id)
             
             return {
                 "success": True,
@@ -187,18 +192,19 @@ class PipelineOrchestrator:
                 "timestamp": datetime.now().isoformat()
             }
     
-    def run_signature_stage(self, agent_name: str = 'ProtocolSignatureGeneratorAgent') -> Dict[str, Any]:
+    def run_signature_stage(self, agent_name: str = 'ProtocolSignatureGeneratorAgent', org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Run only the signature generation stage.
         
         Args:
             agent_name: Agent name to use for signature generation
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             dict: Signature generation results
         """
         try:
-            results = self.orchestrator.run_signature_stage(agent_name)
+            results = self.orchestrator.run_signature_stage(agent_name, org_id=org_id)
             
             return {
                 "success": True,
@@ -216,13 +222,14 @@ class PipelineOrchestrator:
                 "timestamp": datetime.now().isoformat()
             }
     
-    def run_discovery_stage(self, agent_name: str = 'DiscoveryAgent', host: str = None) -> Dict[str, Any]:
+    def run_discovery_stage(self, agent_name: str = 'DiscoveryAgent', host: str = None, org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Run only the network topology discovery stage.
         
         Args:
             agent_name: Agent name to use for discovery
             host: Host/IP address for network topology discovery
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             dict: Discovery results
@@ -236,7 +243,7 @@ class PipelineOrchestrator:
             }
         
         try:
-            results = self.orchestrator.run_discovery_stage(agent_name, host=host)
+            results = self.orchestrator.run_discovery_stage(agent_name, host=host, org_id=org_id)
             
             return {
                 "success": True,

--- a/pgdn/queue.py
+++ b/pgdn/queue.py
@@ -37,18 +37,19 @@ class QueueManager:
             self._queue_manager = create_queue_manager(self.config)
         return self._queue_manager
     
-    def queue_full_pipeline(self, recon_agents: Optional[List[str]] = None) -> Dict[str, Any]:
+    def queue_full_pipeline(self, recon_agents: Optional[List[str]] = None, org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Queue a full pipeline for background processing.
         
         Args:
             recon_agents: Optional list of recon agents to use
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             dict: Queue operation results including task ID
         """
         try:
-            task_id = self.queue_manager.queue_full_pipeline(recon_agents)
+            task_id = self.queue_manager.queue_full_pipeline(recon_agents, org_id=org_id)
             
             return {
                 "success": True,
@@ -81,7 +82,8 @@ class QueueManager:
                           force_rescore: bool = False,
                           host: Optional[str] = None,
                           report_options: Optional[Dict[str, Any]] = None,
-                          force: bool = False) -> Dict[str, Any]:
+                          force: bool = False,
+                          org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Queue a single stage for background processing.
         
@@ -95,6 +97,7 @@ class QueueManager:
             host: Host for discovery stage
             report_options: Options for report stage
             force: Force operation
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             dict: Queue operation results including task ID
@@ -104,12 +107,12 @@ class QueueManager:
                 task_id = self.queue_manager.queue_single_stage(
                     stage, agent_name, recon_agents, protocol_filter,
                     debug, force_rescore, host, report_options=report_options,
-                    force=force
+                    force=force, org_id=org_id
                 )
             else:
                 task_id = self.queue_manager.queue_single_stage(
                     stage, agent_name, recon_agents, protocol_filter,
-                    debug, force_rescore, host, force=force
+                    debug, force_rescore, host, force=force, org_id=org_id
                 )
             
             return {
@@ -137,19 +140,20 @@ class QueueManager:
                 "timestamp": datetime.now().isoformat()
             }
     
-    def queue_target_scan(self, target: str, debug: bool = False) -> Dict[str, Any]:
+    def queue_target_scan(self, target: str, debug: bool = False, org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Queue a target scan for background processing.
         
         Args:
             target: Target to scan
             debug: Enable debug logging
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             dict: Queue operation results including task ID
         """
         try:
-            task_id = self.queue_manager.queue_target_scan(target, debug)
+            task_id = self.queue_manager.queue_target_scan(target, debug, org_id=org_id)
             
             return {
                 "success": True,

--- a/pgdn/reports.py
+++ b/pgdn/reports.py
@@ -46,7 +46,8 @@ class ReportManager:
                        auto_save: bool = False,
                        email_report: bool = False,
                        recipient_email: Optional[str] = None,
-                       force_report: bool = False) -> Dict[str, Any]:
+                       force_report: bool = False,
+                       org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Generate a security analysis report.
         
@@ -60,6 +61,7 @@ class ReportManager:
             email_report: Generate email notification in report
             recipient_email: Recipient email address for notification
             force_report: Force generation even if scan already processed
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             dict: Report generation results
@@ -77,7 +79,7 @@ class ReportManager:
                 'force_report': force_report
             }
             
-            results = self.orchestrator.run_report_stage(agent_name, report_options)
+            results = self.orchestrator.run_report_stage(agent_name, report_options, org_id=org_id)
             
             return {
                 "success": True,
@@ -99,12 +101,13 @@ class ReportManager:
                 "timestamp": datetime.now().isoformat()
             }
     
-    def generate_summary_report(self, scan_id: Optional[int] = None) -> Dict[str, Any]:
+    def generate_summary_report(self, scan_id: Optional[int] = None, org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Generate a summary report with default options.
         
         Args:
             scan_id: Optional specific scan ID to generate report for
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             dict: Report generation results
@@ -113,7 +116,8 @@ class ReportManager:
             agent_name='ReportAgent',
             scan_id=scan_id,
             report_format='summary',
-            auto_save=False
+            auto_save=False,
+            org_id=org_id
         )
     
     def generate_detailed_report(self, scan_id: Optional[int] = None, auto_save: bool = True) -> Dict[str, Any]:

--- a/pgdn/scanner.py
+++ b/pgdn/scanner.py
@@ -35,12 +35,13 @@ class Scanner:
         self.protocol_filter = protocol_filter
         self.debug = debug
     
-    def scan_target(self, target: str) -> Dict[str, Any]:
+    def scan_target(self, target: str, org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Scan a specific target (IP or hostname) directly.
         
         Args:
             target: IP address or hostname to scan
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             dict: Scan results including success status, resolved IP, and scan data
@@ -75,7 +76,7 @@ class Scanner:
                                            debug=self.debug)
             
             # Run the scan using the agent
-            scan_results = scanner_agent.scan_nodes([mock_node])
+            scan_results = scanner_agent.scan_nodes([mock_node], org_id=org_id)
             
             if scan_results:
                 return {
@@ -102,9 +103,12 @@ class Scanner:
                 "timestamp": datetime.now().isoformat()
             }
     
-    def scan_nodes_from_database(self) -> Dict[str, Any]:
+    def scan_nodes_from_database(self, org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Scan nodes discovered in the database using the scan stage.
+        
+        Args:
+            org_id: Optional organization ID to filter agentic jobs
         
         Returns:
             dict: Scan results including success status and scan data
@@ -115,7 +119,7 @@ class Scanner:
             scanner_agent = NodeScannerAgent(self.config, 
                                            protocol_filter=self.protocol_filter, 
                                            debug=self.debug)
-            results = scanner_agent.scan_nodes()
+            results = scanner_agent.scan_nodes(org_id=org_id)
             
             return {
                 "success": True,
@@ -135,13 +139,14 @@ class Scanner:
                 "timestamp": datetime.now().isoformat()
             }
     
-    def scan_parallel_targets(self, targets: List[str], max_parallel: int = 5) -> Dict[str, Any]:
+    def scan_parallel_targets(self, targets: List[str], max_parallel: int = 5, org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Scan multiple targets in parallel.
         
         Args:
             targets: List of targets to scan
             max_parallel: Maximum number of parallel scans
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             dict: Parallel scan results
@@ -155,7 +160,7 @@ class Scanner:
         
         def scan_single_target(target):
             """Helper function for parallel execution."""
-            result = self.scan_target(target)
+            result = self.scan_target(target, org_id=org_id)
             return {
                 "target": target,
                 "success": result["success"],

--- a/pgdn/signatures.py
+++ b/pgdn/signatures.py
@@ -24,7 +24,8 @@ class SignatureManager:
     def learn_from_scans(self,
                         protocol: str,
                         min_confidence: float = 0.7,
-                        max_examples: int = 1000) -> Dict[str, Any]:
+                        max_examples: int = 1000,
+                        org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Learn improved protocol signatures from existing scan data.
         
@@ -32,6 +33,7 @@ class SignatureManager:
             protocol: Protocol name for signature learning (e.g., 'sui', 'filecoin', 'ethereum')
             min_confidence: Minimum confidence threshold for scans to include
             max_examples: Maximum examples to process per protocol
+            org_id: Optional organization ID to filter agentic jobs
             
         Returns:
             dict: Signature learning results
@@ -44,7 +46,8 @@ class SignatureManager:
             results = learning_agent.learn_signatures_from_scans(
                 protocol_name=protocol,
                 min_confidence=min_confidence,
-                max_examples=max_examples
+                max_examples=max_examples,
+                org_id=org_id
             )
             
             return {
@@ -74,7 +77,7 @@ class SignatureManager:
                 "timestamp": datetime.now().isoformat()
             }
     
-    def update_signature_flags(self, protocol_filter: Optional[str] = None) -> Dict[str, Any]:
+    def update_signature_flags(self, protocol_filter: Optional[str] = None, org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Update signature_created flags for scans that have been processed.
         
@@ -114,7 +117,7 @@ class SignatureManager:
                 "timestamp": datetime.now().isoformat()
             }
     
-    def mark_signature_created(self, scan_id: int) -> Dict[str, Any]:
+    def mark_signature_created(self, scan_id: int, org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Mark a specific scan ID as having its signature created.
         
@@ -154,7 +157,7 @@ class SignatureManager:
                 "timestamp": datetime.now().isoformat()
             }
     
-    def get_signature_statistics(self) -> Dict[str, Any]:
+    def get_signature_statistics(self, org_id: Optional[str] = None) -> Dict[str, Any]:
         """
         Get statistics about signature creation status for scans.
         


### PR DESCRIPTION
- Add --org-id argument to CLI parser with examples
- Update all CLI command functions to accept and pass org_id parameter
- Update PGDN library wrapper classes to support org_id:
  - PipelineOrchestrator: all stage methods now accept org_id
  - Scanner: scan_target, scan_nodes_from_database, scan_parallel_targets
  - ReportManager: generate_report and generate_summary_report
  - QueueManager: queue_full_pipeline, queue_single_stage, queue_target_scan
  - ParallelOperations: coordinate_parallel_operation
  - SignatureManager: all signature-related methods
- All org_id parameters are optional to maintain backward compatibility
- Ready for implementation of actual SQL filtering logic in agents